### PR TITLE
build(requirements) install python-dotenv to support .env

### DIFF
--- a/build/requirements.txt
+++ b/build/requirements.txt
@@ -4,3 +4,4 @@ google-cloud-ndb==1.7.1
 google-auth==1.30.1
 google-cloud-logging==2.1.1
 flake8==3.7.7
+python-dotenv==0.20.0


### PR DESCRIPTION
To support .env files you need to install "python-dotenv". This adds it to the the `requirements.txt`